### PR TITLE
Fix/update documentation to avoid module shadowing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ impresso.egg-info/*
 tmp/
 dist/
 site/
+.python-version

--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ poetry run flake8 impresso tests
 poetry run mypy impresso tests
 ```
 
+### Run Documentation
+
+If you want to write or update the documentation (the content published on Read the Docs), edit the Markdown files in the `docs/` folder and then run the commands below to check your changes locally.
+
+```shell
+poetry install --with docs
+poetry run mkdocs serve
+```
+
+Open the local URL shown in the terminal (usually `http://127.0.0.1:8000`) to preview the documentation and verify that pages render correctly.
+
+To run a build check (the same type of check used for publication), use:
+
+```shell
+poetry run mkdocs build
+```
+
 ### OpenAPI client generation
 
 The OpenAPI client is generated using the OpenAPI Generator. Pydantic models from the OpenAPI spec are generated too. The following command generates both the client code and the pydantic models. Make sure the Public API is running on `localhost`.:

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ from impresso import connect
 client = connect()
 ```
 
-### Search 
+### Search
 
 ```python
 results = client.search.find(term="moon landing")
@@ -37,20 +37,21 @@ results
 ```python
 results.df
 ```
+
 ### Pagination
 
 !!! warning "Monthly Quota"
-    Every Impresso user has a monthly quota of the content items they can access.
-    The quota is currently set at 200,000 content items. Paginating through a
-    large result set may see you hitting the quota limit fairly soon.
-    Make sure to check the size of the full result set before fetching all pages.
+Every Impresso user has a monthly quota of the content items they can access.
+The quota is currently set at 200,000 content items. Paginating through a
+large result set may see you hitting the quota limit fairly soon.
+Make sure to check the size of the full result set before fetching all pages.
 
 By default every result object is the first page of the full result set. Use the following code to go through the rest of the pages:
 
 ```python
 import pandas as pd
 # Get first page with 100 items per page
-results = impresso.search.find(term="landing", limit=100)
+results = client.search.find(term="landing", limit=100)
 print(f"Full result contains {results.total} items.")
 
 full_df = results.df
@@ -73,6 +74,7 @@ result.df['text.content'][0]
 ```
 
 ### See content item on Web App (shortcut)
+
 To see a specific content item in the Web App, look for the link "See this result in the Impresso App" in the rendered result summary:
 
 ```python


### PR DESCRIPTION
The documentation showed impresso = impresso.connect(), which shadows the module name and prevents access to module-level exports like DateRange, AND, and OR.
Changes

- Function docstring: Updated connect() example from impresso = connect() to client = connect()

### Before - shadows the module
```python
from impresso import connect
impresso = connect()
impresso.search.find(...)  # Can't use impresso.DateRange anymore
```

### After - keeps module accessible
```python
from impresso import connect
client = connect()
client.search.find(...)  # Can still use impresso.DateRange, impresso.AND, etc.
```